### PR TITLE
Task 8 - Docker and AWS Elastic Beanstalk

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -3,7 +3,7 @@ const API_PATHS = {
   order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   import: 'https://gtgr83serk.execute-api.eu-west-1.amazonaws.com/dev',
   bff: 'https://v7epzfc1vd.execute-api.eu-west-1.amazonaws.com/dev',
-  cart: 'http://thorsangervanet-cart-api-dev.eu-west-1.elasticbeanstalk.com/api',
+  cart: 'https://hwh9egqhs6.execute-api.eu-west-1.amazonaws.com/api',
 };
 
 export default API_PATHS;

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -3,7 +3,7 @@ const API_PATHS = {
   order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   import: 'https://gtgr83serk.execute-api.eu-west-1.amazonaws.com/dev',
   bff: 'https://v7epzfc1vd.execute-api.eu-west-1.amazonaws.com/dev',
-  cart: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
+  cart: 'http://thorsangervanet-cart-api-dev.eu-west-1.elasticbeanstalk.com/api',
 };
 
 export default API_PATHS;


### PR DESCRIPTION
FE URL - https://dkct2oxjblzy1.cloudfront.net/
Update apiPaths according to Task 8. 
FE was updated with Api Gateway proxy URL for Cart API to make it accessible through HTTPS.